### PR TITLE
🐛  유저 검색 후 프로필 페이지 이동 시 에러로 window.location.origin 제거

### DIFF
--- a/src/js/home.js
+++ b/src/js/home.js
@@ -192,7 +192,7 @@ async function findUser() {
         console.log(currentTarget);
         const { useraccount } = currentTarget.dataset;
 
-        location.href = `${window.location.origin}/profile.html?${useraccount}`;
+        location.href = `/profile.html?${useraccount}`;
       });
     });
   }


### PR DESCRIPTION
# 상세내용
 유저 검색 후 프로필 페이지 이동시 404 에러발생

# 이슈번호: #66